### PR TITLE
Update Neo4JMembership.cs

### DIFF
--- a/Neo4JMembership.cs
+++ b/Neo4JMembership.cs
@@ -1684,6 +1684,7 @@ namespace Nextwave.Neo4J.Membership
 
         private string EncodePassword(string password)
         {
+            password = string.IsNullOrEmpty(password) ? "placeholder" : password;
             string encodedPassword = password;
 
             switch (PasswordFormat)


### PR DESCRIPTION
Added a null string catch for the 'string password' when requiresQuestionAndAnswer="false" is set in the web.config.
